### PR TITLE
Fixes an issue in the double peak filter

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -49,7 +49,7 @@ const Utilities = {
   },
 
   peakFilter(energies, sensitivity) {
-    energies = energies.sort().reverse();
+    energies = energies.sort((a, b) => (a - b)).reverse();
     let peak       = energies[0],
         secondPeak = energies[1],
         thirdPeak  = energies[2],


### PR DESCRIPTION
Javascript's sort sorts alphabetically by the string representation, resulting in seemingly random energies when small numbers are involved. This is because the string representation eventually changes to scientific notation.

![image](https://user-images.githubusercontent.com/7272789/186637411-7039b851-4419-4eac-8b0f-9fc32daa8da9.png)

This PR fixes it by passing a comparator.

